### PR TITLE
Remove unneeded array. Fixes #4

### DIFF
--- a/src/AppBundle/Entity/Department.php
+++ b/src/AppBundle/Entity/Department.php
@@ -154,16 +154,12 @@ class Department
 
         $callouts_pos = array();
 
-        $ids = [];
-
         foreach ($p as $index => $member) {
           foreach ($callouts_names as $names) {
             if (strpos($member->getPosition(), $names) !== false) {
-                if (!in_array($member->getId(), $ids)) {
-                  $callouts_pos[$names][]=$member;
-                  $ids[] = $member->getId();
-                  unset($p[$index]);
-                }
+                $callouts_pos[$names][]=$member;
+                unset($p[$index]);
+                break; // Stop looking for positions for this member.
             }
           }
         }


### PR DESCRIPTION
Event though we unset $p[$index], $member is still in scope as we continued to loop over $callout_pos. Adding a break means that once a position is found we stop looping over $callout_pos.